### PR TITLE
Added extra check for 'sources' key if 'file' key not found.

### DIFF
--- a/JWPlayer.php
+++ b/JWPlayer.php
@@ -91,7 +91,19 @@ class JWPlayer extends Widget
         foreach ($this->_requiredOptions as $key)
         {
             if ( ! ArrayHelper::keyExists($key, $this->_playerOptions, false) ) {
-                throw new InvalidConfigException("JWPlayer Widget: player options missing '$key'");
+                if ( $key == 'file' ) {
+                    if ( ! ArrayHelper::keyExists('sources', $this->_playerOptions, false ) ) {
+
+                        throw new InvalidConfigException("JWPlayer Widget: player options missing '$key'");
+                   
+                    } else if ( empty( $this->_playerOptions['sources'] ) ) {
+
+                        throw new InvalidConfigException("JWPlayer Widget: sources cannot be empty");
+                    }
+                } else {
+
+                    throw new InvalidConfigException("JWPlayer Widget: player options missing '$key'");
+                }
             }
         }
     }


### PR DESCRIPTION
Added secondary nested check for a 'sources' key if the required 'file' key isn't found to allow support for multiple video sources (fallbacks).